### PR TITLE
Fix bug crash for SaveFileDialog when using root directory

### DIFF
--- a/src/Ookii.Dialogs.WinForms/VistaFileDialog.cs
+++ b/src/Ookii.Dialogs.WinForms/VistaFileDialog.cs
@@ -657,17 +657,13 @@ namespace Ookii.Dialogs.WinForms
             // Set the default file name
             if( !(_fileNames == null || _fileNames.Length == 0 || string.IsNullOrEmpty(_fileNames[0])) )
             {
-                string parent = Path.GetDirectoryName(_fileNames[0]);
-                if( parent == null || !Directory.Exists(parent) )
-                {
-                    dialog.SetFileName(_fileNames[0]);
-                }
-                else
-                {
-                    string folder = Path.GetFileName(_fileNames[0]);
-                    dialog.SetFolder(NativeMethods.CreateItemFromParsingName(parent));
-                    dialog.SetFileName(folder);
-                }
+                dialog.SetFileName(_fileNames[0]);
+            }
+
+            // Set the default directory
+            if( Directory.Exists(_initialDirectory) )
+            {
+                dialog.SetFolder(NativeMethods.CreateItemFromParsingName(_initialDirectory));
             }
 
             // Set the filter
@@ -690,13 +686,6 @@ namespace Ookii.Dialogs.WinForms
             if( _addExtension && !string.IsNullOrEmpty(_defaultExt) )
             {
                 dialog.SetDefaultExtension(_defaultExt);
-            }
-
-            // Initial directory
-            if( !string.IsNullOrEmpty(_initialDirectory) )
-            {
-                Interop.IShellItem item = NativeMethods.CreateItemFromParsingName(_initialDirectory);
-                dialog.SetDefaultFolder(item);
             }
 
             // ShowHelp

--- a/src/Ookii.Dialogs.WinForms/VistaFolderBrowserDialog.cs
+++ b/src/Ookii.Dialogs.WinForms/VistaFolderBrowserDialog.cs
@@ -48,8 +48,17 @@ namespace Ookii.Dialogs.WinForms
         /// Creates a new instance of the <see cref="VistaFolderBrowserDialog" /> class.
         /// </summary>
         public VistaFolderBrowserDialog()
+            : this(false)
         {
-            if( !IsVistaFolderDialogSupported )
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="VistaFolderBrowserDialog" /> class.
+        /// </summary>
+        /// <param name="forceDownlevel">When <see langword="true"/>, the old style common file dialog will always be used even if the OS supports the Vista style.</param>
+        public VistaFolderBrowserDialog(bool forceDownlevel)
+        {
+            if (forceDownlevel || !IsVistaFolderDialogSupported)
                 _downlevelDialog = new FolderBrowserDialog();
             else
                 Reset();
@@ -278,22 +287,13 @@ namespace Ookii.Dialogs.WinForms
                 }
             }
 
-            dialog.SetOptions(NativeMethods.FOS.FOS_PICKFOLDERS | NativeMethods.FOS.FOS_FORCEFILESYSTEM | NativeMethods.FOS.FOS_FILEMUSTEXIST);
-
-            if( !string.IsNullOrEmpty(_selectedPath) )
+            // Set the default directory
+            if (Directory.Exists(_selectedPath))
             {
-                string parent = Path.GetDirectoryName(_selectedPath);
-                if( parent == null || !Directory.Exists(parent) )
-                {
-                    dialog.SetFileName(_selectedPath);
-                }
-                else
-                {
-                    string folder = Path.GetFileName(_selectedPath);
-                    dialog.SetFolder(NativeMethods.CreateItemFromParsingName(parent));
-                    dialog.SetFileName(folder);
-                }
+                dialog.SetFolder(NativeMethods.CreateItemFromParsingName(_selectedPath));
             }
+
+            dialog.SetOptions(NativeMethods.FOS.FOS_PICKFOLDERS | NativeMethods.FOS.FOS_FORCEFILESYSTEM | NativeMethods.FOS.FOS_FILEMUSTEXIST);
         }
 
         private void GetResult(Ookii.Dialogs.WinForms.Interop.IFileDialog dialog)


### PR DESCRIPTION
- Add forceDownLevel optional for FolderBrowserDialog
- Fix bug property for FileDialog and FolderDialog when using root directory path (example C:// for SaveFileDialog)